### PR TITLE
Quote tempfile name in regexps 

### DIFF
--- a/t/archive.t
+++ b/t/archive.t
@@ -20,7 +20,7 @@ my $temp = testdata::setup::tmpdir();
     );
     trap { $a->run; };
     is ( $trap->exit, undef, 'exit() == undef' );
-    like($trap->stdout,qr/archived coverage reports at $temp/,'command output location');
+    like($trap->stdout,qr/archived coverage reports at \Q$temp\E/,'command output location');
 
     foreach my $file (qw(index.html cover.css archive_db 2012-02-20T18:20:00/coverage.html)) {
         file_exists_ok($temp->file('archive',$file));
@@ -51,7 +51,7 @@ my $temp = testdata::setup::tmpdir();
     );
     trap { $a->run; };
     is ( $trap->exit, undef, 'exit() == undef' );
-    like($trap->stdout,qr/archived coverage reports at $temp/,'command output location');
+    like($trap->stdout,qr/archived coverage reports at \Q$temp\E/,'command output location');
 
     foreach my $file (qw(index.html cover.css archive_db 2012-02-20T19:40:00/coverage.html)) {
         file_exists_ok($temp->file('archive',$file));


### PR DESCRIPTION
Some OSes (like Mac OS X) have a TMPDIR with regexp
meta-chars (like +), so we need to quote the
filename in the regexps.
