### PR TITLE
Enable experimental switch.

### DIFF
--- a/lib/App/ArchiveDevelCover.pm
+++ b/lib/App/ArchiveDevelCover.pm
@@ -5,6 +5,7 @@ use MooseX::Types::Path::Class;
 use DateTime;
 use File::Copy;
 use HTML::TableExtract;
+use experimental qw(switch);
 
 # ABSTRACT: Archive Devel::Cover reports
 our $VERSION = '1.002';


### PR DESCRIPTION
Avoid warnings when using `given` / `when`. This fixes issue #2. 

_[[Assigned by [pullrequest.club](https://pullrequest.club)]]_